### PR TITLE
Update Room.tsx

### DIFF
--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -31,7 +31,10 @@ export const Room = ({
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
-    const socket = io(URL);
+     const socket = io(URL, {
+      transports: ['websocket'], // Use only WebSocket
+      withCredentials: true,      // Allow credentials (cookies/auth headers)
+    });
     socketRef.current = socket;
 
     const initializePeerConnection = () => {


### PR DESCRIPTION
## Description
By default, Socket.IO uses polling transport before upgrading to WebSocket. so now we are doing force WebSocket-only transport to reduce issues with CORS and preflight requests.


